### PR TITLE
fix: order of tags in compare link

### DIFF
--- a/src/templates/header.hbs
+++ b/src/templates/header.hbs
@@ -16,7 +16,7 @@
   {{~else}}
     {{~@root.repoUrl}}/
   {{~/if~}}
-  compare/{{previousTag}}%0D{{currentTag}})
+  compare/{{currentTag}}%0D{{previousTag}})
 {{~else}}
   {{~version}}
 {{~/if}}


### PR DESCRIPTION
Bitbucket compare links first receives the most recent tag and then the previous tag.